### PR TITLE
feat/be: 회원가입 기능 구현 및 security 설정

### DIFF
--- a/backend/src/main/java/com/back/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/back/domain/member/controller/MemberController.java
@@ -1,0 +1,4 @@
+package com.back.domain.member.controller;
+
+public class MemberController {
+}

--- a/backend/src/main/java/com/back/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/back/domain/member/controller/MemberController.java
@@ -1,4 +1,61 @@
 package com.back.domain.member.controller;
 
+import com.back.domain.member.dto.MemberDto;
+import com.back.domain.member.entity.Member;
+import com.back.domain.member.enums.Role;
+import com.back.domain.member.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+@Tag(name = "MemberController", description = "API 회원 컨트롤러")
+@SecurityRequirement(name = "bearerAuth")
 public class MemberController {
+    private final MemberService memberService;
+
+    record MemberJoinReqBody(
+            @NotBlank
+            @Size(min = 2, max = 30)
+            String email,
+            @NotBlank
+            @Size(min = 2, max = 30)
+            String password,
+            @NotBlank
+            @Size(min = 2, max = 30)
+            String nickname,
+            @NotBlank
+            @Size(min = 2, max = 30)
+            String address,
+            @NotNull
+            Role role
+    ) {
+    }
+
+    @PostMapping
+    @Transactional
+    @Operation(summary = "가입")
+    public MemberDto join(@Valid @RequestBody MemberJoinReqBody reqBody) {
+        Member member = memberService.join(
+                reqBody.email(),
+                reqBody.password(),
+                reqBody.nickname(),
+                reqBody.address(),
+                reqBody.role() // USER, ADMIN을 입력하면 스프링이 자동으로 enum으로 매핑.
+        );
+
+        return new MemberDto(member);
+    }
 }

--- a/backend/src/main/java/com/back/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/back/domain/member/controller/MemberController.java
@@ -1,17 +1,16 @@
 package com.back.domain.member.controller;
 
 import com.back.domain.member.dto.MemberDto;
+import com.back.domain.member.dto.MemberJoinRequestDto;
 import com.back.domain.member.entity.Member;
-import com.back.domain.member.enums.Role;
 import com.back.domain.member.service.MemberService;
+import com.back.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,35 +18,19 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Tag(name = "MemberController", description = "API 회원 컨트롤러")
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
-@Tag(name = "MemberController", description = "API 회원 컨트롤러")
 @SecurityRequirement(name = "bearerAuth")
 public class MemberController {
     private final MemberService memberService;
 
-    record MemberJoinReqBody(
-            @NotBlank
-            @Size(min = 2, max = 30)
-            String email,
-            @NotBlank
-            @Size(min = 2, max = 30)
-            String password,
-            @NotBlank
-            @Size(min = 2, max = 30)
-            String nickname,
-            @NotBlank
-            @Size(min = 2, max = 30)
-            String address,
-            @NotNull
-            Role role
-    ) {
-    }
-
+    @Operation(summary = "회원가입", description = "회원가입 API")
     @PostMapping
     @Transactional
-    @Operation(summary = "가입")
-    public MemberDto join(@Valid @RequestBody MemberJoinReqBody reqBody) {
+    public ResponseEntity<ApiResponse<MemberDto>> join(
+            @Valid @RequestBody MemberJoinRequestDto reqBody
+    ) {
         Member member = memberService.join(
                 reqBody.email(),
                 reqBody.password(),
@@ -56,6 +39,12 @@ public class MemberController {
                 reqBody.role() // USER, ADMIN을 입력하면 스프링이 자동으로 enum으로 매핑.
         );
 
-        return new MemberDto(member);
+        // 성공 응답
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "%s님 환영합니다. 회원가입이 완료되었습니다.".formatted(member.getNickname()),
+                        new MemberDto(member)
+                )
+        );
     }
 }

--- a/backend/src/main/java/com/back/domain/member/dto/MemberDto.java
+++ b/backend/src/main/java/com/back/domain/member/dto/MemberDto.java
@@ -1,0 +1,29 @@
+package com.back.domain.member.member.dto;
+
+import com.back.domain.member.member.entity.Member;
+import org.springframework.lang.NonNull;
+
+import java.time.LocalDateTime;
+
+public record MemberDto(
+        @NonNull int id,
+        @NonNull LocalDateTime createDate,
+        @NonNull LocalDateTime modifyDate,
+        @NonNull String name
+) {
+    public MemberDto(int id, LocalDateTime createDate, LocalDateTime modifyDate, String name) {
+        this.id = id;
+        this.createDate = createDate;
+        this.modifyDate = modifyDate;
+        this.name = name;
+    }
+
+    public MemberDto(Member member) {
+        this(
+                member.getId(),
+                member.getCreateDate(),
+                member.getModifyDate(),
+                member.getName()
+        );
+    }
+}

--- a/backend/src/main/java/com/back/domain/member/dto/MemberDto.java
+++ b/backend/src/main/java/com/back/domain/member/dto/MemberDto.java
@@ -1,29 +1,29 @@
-package com.back.domain.member.member.dto;
+package com.back.domain.member.dto;
 
-import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.entity.Member;
 import org.springframework.lang.NonNull;
 
 import java.time.LocalDateTime;
 
 public record MemberDto(
-        @NonNull int id,
-        @NonNull LocalDateTime createDate,
-        @NonNull LocalDateTime modifyDate,
-        @NonNull String name
+        @NonNull long id,
+        @NonNull LocalDateTime createdAt,
+        @NonNull LocalDateTime editedAt,
+        @NonNull String nickname
 ) {
-    public MemberDto(int id, LocalDateTime createDate, LocalDateTime modifyDate, String name) {
+    public MemberDto(long id, LocalDateTime createdAt, LocalDateTime editedAt, String nickname) {
         this.id = id;
-        this.createDate = createDate;
-        this.modifyDate = modifyDate;
-        this.name = name;
+        this.createdAt = createdAt;
+        this.editedAt = editedAt;
+        this.nickname = nickname;
     }
 
     public MemberDto(Member member) {
         this(
                 member.getId(),
-                member.getCreateDate(),
-                member.getModifyDate(),
-                member.getName()
+                member.getCreatedAt(),
+                member.getEditedAt(),
+                member.getNickname()
         );
     }
 }

--- a/backend/src/main/java/com/back/domain/member/dto/MemberJoinRequestDto.java
+++ b/backend/src/main/java/com/back/domain/member/dto/MemberJoinRequestDto.java
@@ -1,0 +1,36 @@
+package com.back.domain.member.dto;
+
+import com.back.domain.member.enums.Role;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "회원가입 요청 DTO")
+public record MemberJoinRequestDto(
+        @NotBlank
+        @Size(min = 2, max = 50)
+        @Schema(description = "이메일", example = "user@example.com")
+        String email,
+
+        // BCrypt 암호화 방식의 경우 60자
+        @NotBlank
+        @Size(min = 2, max = 60)
+        @Schema(description = "비밀번호", example = "securePassword123")
+        String password,
+
+        @NotBlank
+        @Size(min = 2, max = 30)
+        @Schema(description = "닉네임", example = "nickname123")
+        String nickname,
+
+        @NotBlank
+        @Size(min = 2, max = 100)
+        @Schema(description = "주소", example = "서울시 강남구 역삼동")
+        String address,
+
+        @NotNull
+        @Schema(description = "역할", example = "USER / ADMIN")
+        Role role
+) {
+}

--- a/backend/src/main/java/com/back/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/back/domain/member/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.back.domain.member.member.repository;
+
+import com.back.domain.member.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Integer> {
+    Optional<Member> findByUsername(String username);
+
+    Optional<Member> findByApiKey(String apiKey);
+}

--- a/backend/src/main/java/com/back/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/back/domain/member/repository/MemberRepository.java
@@ -1,12 +1,14 @@
-package com.back.domain.member.member.repository;
+package com.back.domain.member.repository;
 
-import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.entity.Member;
+import com.back.global.jwt.refreshtoken.entity.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Integer> {
-    Optional<Member> findByUsername(String username);
+    Optional<Member> findByEmail(String email);
 
-    Optional<Member> findByApiKey(String apiKey);
+    Optional<Member> findByRefreshToken(RefreshToken refreshToken);
+
 }

--- a/backend/src/main/java/com/back/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/back/domain/member/service/MemberService.java
@@ -1,0 +1,67 @@
+package com.back.domain.member.member.service;
+
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.repository.MemberRepository;
+import com.back.global.exception.ServiceException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final AuthTokenService authTokenService;
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public long count() {
+        return memberRepository.count();
+    }
+
+    public Member join(String username, String password, String nickname) {
+        memberRepository
+                .findByUsername(username)
+                .ifPresent(_member -> {
+                    throw new ServiceException("409-1", "이미 존재하는 아이디입니다.");
+                });
+
+        password = passwordEncoder.encode(password);
+
+        Member member = new Member(username, password, nickname);
+
+        return memberRepository.save(member);
+    }
+
+    public Optional<Member> findByUsername(String username) {
+        return memberRepository.findByUsername(username);
+    }
+
+    public Optional<Member> findByApiKey(String apiKey) {
+        return memberRepository.findByApiKey(apiKey);
+    }
+
+    public String genAccessToken(Member member) {
+        return authTokenService.genAccessToken(member);
+    }
+
+    public Map<String, Object> payload(String accessToken) {
+        return authTokenService.payload(accessToken);
+    }
+
+    public Optional<Member> findById(int id) {
+        return memberRepository.findById(id);
+    }
+
+    public List<Member> findAll() {
+        return memberRepository.findAll();
+    }
+
+    public void checkPassword(Member member, String password) {
+        if (!passwordEncoder.matches(password, member.getPassword()))
+            throw new ServiceException("401-1", "비밀번호가 일치하지 않습니다.");
+    }
+}

--- a/backend/src/main/java/com/back/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/back/domain/member/service/MemberService.java
@@ -20,19 +20,24 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public long count() {
-        return memberRepository.count();
-    }
-
     public Member join(String email, String password, String nickname, String address, Role role) {
+        // 이메일 중복 체크
         memberRepository
                 .findByEmail(email)
                 .ifPresent(_member -> {
                     throw new CustomException(ErrorCode.DEV_NOT_FOUND);
                 });
 
-        Member member = new Member(email, passwordEncoder.encode(password), nickname, address, role);
+        // 회원 생성. 매개변수 3개 이상일 경우엔 빌드패턴 사용 권장.
+        Member member = Member.builder()
+                .email(email)
+                .password(passwordEncoder.encode(password))
+                .nickname(nickname)
+                .address(address)
+                .role(role)
+                .build();
 
+        // 저장
         return memberRepository.save(member);
     }
 

--- a/backend/src/main/java/com/back/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/back/domain/member/service/MemberService.java
@@ -1,20 +1,22 @@
-package com.back.domain.member.member.service;
+package com.back.domain.member.service;
 
-import com.back.domain.member.member.entity.Member;
-import com.back.domain.member.member.repository.MemberRepository;
-import com.back.global.exception.ServiceException;
+import com.back.domain.member.entity.Member;
+import com.back.domain.member.enums.Role;
+import com.back.domain.member.repository.MemberRepository;
+import com.back.global.exception.CustomException;
+import com.back.global.exception.ErrorCode;
+import com.back.global.jwt.refreshtoken.entity.RefreshToken;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
-    private final AuthTokenService authTokenService;
+//    private final AuthTokenService authTokenService;
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
@@ -22,34 +24,24 @@ public class MemberService {
         return memberRepository.count();
     }
 
-    public Member join(String username, String password, String nickname) {
+    public Member join(String email, String password, String nickname, String address, Role role) {
         memberRepository
-                .findByUsername(username)
+                .findByEmail(email)
                 .ifPresent(_member -> {
-                    throw new ServiceException("409-1", "이미 존재하는 아이디입니다.");
+                    throw new CustomException(ErrorCode.DEV_NOT_FOUND);
                 });
 
-        password = passwordEncoder.encode(password);
-
-        Member member = new Member(username, password, nickname);
+        Member member = new Member(email, passwordEncoder.encode(password), nickname, address, role);
 
         return memberRepository.save(member);
     }
 
-    public Optional<Member> findByUsername(String username) {
-        return memberRepository.findByUsername(username);
+    public Optional<Member> findByEmail(String email) {
+        return memberRepository.findByEmail(email);
     }
 
-    public Optional<Member> findByApiKey(String apiKey) {
-        return memberRepository.findByApiKey(apiKey);
-    }
-
-    public String genAccessToken(Member member) {
-        return authTokenService.genAccessToken(member);
-    }
-
-    public Map<String, Object> payload(String accessToken) {
-        return authTokenService.payload(accessToken);
+    public Optional<Member> findByRefreshToken(RefreshToken refreshToken) {
+        return memberRepository.findByRefreshToken(refreshToken);
     }
 
     public Optional<Member> findById(int id) {
@@ -62,6 +54,6 @@ public class MemberService {
 
     public void checkPassword(Member member, String password) {
         if (!passwordEncoder.matches(password, member.getPassword()))
-            throw new ServiceException("401-1", "비밀번호가 일치하지 않습니다.");
+            throw new CustomException(ErrorCode.DEV_NOT_FOUND);
     }
 }

--- a/backend/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/back/global/security/SecurityConfig.java
@@ -1,0 +1,4 @@
+package com.back.global.security;
+
+public class SecurityConfig {
+}

--- a/backend/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/back/global/security/SecurityConfig.java
@@ -22,10 +22,11 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests(
                         auth -> auth
-                                .requestMatchers("/favicon.ico").permitAll()
-                                .requestMatchers("/h2-console/**").permitAll()
-                                .requestMatchers("/api/auth/**").permitAll()
-                                .anyRequest().authenticated()
+//                                .requestMatchers("/favicon.ico").permitAll()
+//                                .requestMatchers("/h2-console/**").permitAll()
+//                                .requestMatchers("/api/auth/**").permitAll()
+//                                .anyRequest().authenticated()
+                                .anyRequest().permitAll()
                 )
                 .headers(
                         headers -> headers
@@ -61,6 +62,7 @@ public class SecurityConfig {
 
         return source;
     }
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();

--- a/backend/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/back/global/security/SecurityConfig.java
@@ -1,4 +1,68 @@
 package com.back.global.security;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(
+                        auth -> auth
+                                .requestMatchers("/favicon.ico").permitAll()
+                                .requestMatchers("/h2-console/**").permitAll()
+                                .requestMatchers("/api/auth/**").permitAll()
+                                .anyRequest().authenticated()
+                )
+                .headers(
+                        headers -> headers
+                                .frameOptions(
+                                        HeadersConfigurer.FrameOptionsConfig::sameOrigin
+                                )
+                ).csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(AbstractHttpConfigurer::disable);
+
+        return http.build();
+    }
+
+    @Bean
+    public UrlBasedCorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        // 허용할 오리진 설정
+        configuration.setAllowedOrigins(List.of("https://cdpn.io", "http://localhost:3000"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE"));
+
+        // 자격 증명 허용 설정
+        configuration.setAllowCredentials(true);
+
+        // 허용할 헤더 설정
+        configuration.setAllowedHeaders(List.of("*"));
+
+        // CORS 설정을 소스에 등록
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/api/**", configuration);
+
+        return source;
+    }
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 }


### PR DESCRIPTION
### 📌 과제 설명 
회원가입 기능 구현 및 security 설정
----------------

### 👩‍💻 요구 사항과 구현 내용 
- [X] postman에서 {{baseURL}}/api/auth 에 POST 요청으로 회원가입 성공
- [X]  원활한 개발을 위해 Spring Security 간략하게 세팅
- [X] 중복 회원가입 시 에러 출력
- [X] 회원가입 성공 시 DB에 저장
------------------

### ✅ 특이 사항 
 - member id, address. createdAt, editedAt, email, nickname, password(암호화), role 만 저장됩니다.
 - cart, refresh_token는 아직 미구현입니다.
------------------

### 📕 관련 이슈
closed #1 (#닫고싶은 이슈번호)