### PR TITLE
feat/be 토큰 재발급 로직, 쿠키 구현

### DIFF
--- a/backend/src/main/java/com/back/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/back/domain/member/controller/MemberController.java
@@ -4,9 +4,6 @@ import com.back.domain.member.dto.MemberDto;
 import com.back.domain.member.dto.MemberJoinRequestDto;
 import com.back.domain.member.dto.MemberLoginRequestDto;
 import com.back.domain.member.dto.MemberLoginResponseDto;
-import com.back.domain.member.entity.Member;
-import com.back.domain.member.exception.MemberErrorCode;
-import com.back.domain.member.exception.MemberException;
 import com.back.domain.member.service.MemberService;
 import com.back.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,8 +12,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @Tag(name = "MemberController", description = "API 회원 컨트롤러")
@@ -28,52 +27,32 @@ public class MemberController {
 
     @Operation(summary = "회원가입", description = "회원가입 API")
     @PostMapping
-    @Transactional
     public ResponseEntity<ApiResponse<MemberDto>> join(
             @Valid @RequestBody MemberJoinRequestDto reqBody
     ) {
-        Member member = memberService.join(
-                reqBody.email(),
-                reqBody.password(),
-                reqBody.nickname(),
-                reqBody.address(),
-                reqBody.role() // USER, ADMIN을 입력하면 스프링이 자동으로 enum으로 매핑.
-        );
+        MemberDto memberDto = memberService.join(reqBody);
 
         // 성공 응답
         return ResponseEntity.ok(
                 ApiResponse.success(
-                        "%s님 환영합니다. 회원가입이 완료되었습니다.".formatted(member.getNickname()),
-                        new MemberDto(member)
+                        "%s님 환영합니다. 회원가입이 완료되었습니다.".formatted(memberDto.nickname()),
+                        memberDto
                 )
         );
     }
 
     @Operation(summary = "로그인", description = "로그인 API")
     @PostMapping("/login")
-    @Transactional(readOnly = true)
     public ResponseEntity<ApiResponse<MemberLoginResponseDto>> login(
             @Valid @RequestBody MemberLoginRequestDto reqBody
     ) {
-        Member member = memberService.findByEmail(reqBody.email())
-                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
-
-        memberService.checkPassword(
-                member,
-                reqBody.password()
-        );
-
-        String accessToken = memberService.generateAccessToken(member);
+        MemberLoginResponseDto memberLoginResponseDto = memberService.login(reqBody);
 
         // 성공 응답
         return ResponseEntity.ok(
                 ApiResponse.success(
-                        "%s님 환영합니다.".formatted(member.getNickname()),
-                        new MemberLoginResponseDto(
-                                new MemberDto(member),
-                                accessToken,
-                                member.getRefreshToken().getToken()
-                        )
+                        "%s님 환영합니다.".formatted(memberLoginResponseDto.memberDto().nickname()),
+                        memberLoginResponseDto
                 )
         );
     }

--- a/backend/src/main/java/com/back/domain/member/dto/MemberLoginResponseDto.java
+++ b/backend/src/main/java/com/back/domain/member/dto/MemberLoginResponseDto.java
@@ -1,7 +1,10 @@
 package com.back.domain.member.dto;
 
+import com.back.domain.member.enums.Role;
+
 public record MemberLoginResponseDto(
-        MemberDto item,
+        MemberDto memberDto,
+        Role role,
         String accessToken,
         String refreshToken
 ) {

--- a/backend/src/main/java/com/back/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/back/domain/member/entity/Member.java
@@ -69,12 +69,15 @@ public class Member {
     private RefreshToken refreshToken;
 
     @Builder
-    public Member(String email, String password, String nickname, String address, Role role, RefreshToken refreshToken) {
+    public Member(String email, String password, String nickname, String address, Role role) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
         this.address = address;
         this.role = role;
+    }
+
+    public void setRefreshToken(RefreshToken refreshToken) {
         this.refreshToken = refreshToken;
     }
 

--- a/backend/src/main/java/com/back/domain/member/exception/MemberErrorCode.java
+++ b/backend/src/main/java/com/back/domain/member/exception/MemberErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum MemberErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-404", "해당 회원을 찾을 수 없습니다."),
     MEMBER_ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-414", "해당 회원의 주소를 찾을 수 없습니다."),
-    ACCESS_DENIED(HttpStatus.BAD_REQUEST, "ADMIN-400", "관리자 권한이 없습니다."),;
+    ACCESS_DENIED(HttpStatus.BAD_REQUEST, "ADMIN-400", "관리자 권한이 없습니다."),
+    MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "MEMBER-409", "해당 회원이 이미 가입되어 있습니다."),;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/backend/src/main/java/com/back/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/back/domain/member/service/MemberService.java
@@ -1,60 +1,128 @@
 package com.back.domain.member.service;
 
+import com.back.domain.member.dto.MemberDto;
+import com.back.domain.member.dto.MemberJoinRequestDto;
+import com.back.domain.member.dto.MemberLoginRequestDto;
+import com.back.domain.member.dto.MemberLoginResponseDto;
 import com.back.domain.member.entity.Member;
-import com.back.domain.member.enums.Role;
 import com.back.domain.member.exception.MemberErrorCode;
 import com.back.domain.member.exception.MemberException;
 import com.back.domain.member.repository.MemberRepository;
 import com.back.global.jwt.authtoken.service.AuthTokenService;
 import com.back.global.jwt.refreshtoken.entity.RefreshToken;
+import com.back.global.jwt.refreshtoken.repository.RefreshTokenRepository;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
     private final AuthTokenService authTokenService;
     private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
+    private final HttpServletResponse resp;
 
-    public Member join(String email, String password, String nickname, String address, Role role) {
+    // 회원가입 로직
+    @Transactional
+    public MemberDto join(MemberJoinRequestDto reqBody) {
         // 이메일 중복 체크
         memberRepository
-                .findByEmail(email)
+                .findByEmail(reqBody.email())
                 .ifPresent(_member -> {
-                    throw new MemberException(MemberErrorCode.MEMBER_NOT_FOUND);
+                    throw new MemberException(MemberErrorCode.MEMBER_ALREADY_EXISTS);
                 });
-
-        // 리프레시 토큰 저장
-        RefreshToken refreshToken = RefreshToken.builder()
-                .token(generateRefreshToken())
-                .build();
 
         // 회원 생성. 매개변수 3개 이상일 경우엔 빌드패턴 사용 권장.
         Member member = Member.builder()
-                        .email(email)
-                        .password(passwordEncoder.encode(password))
-                        .nickname(nickname)
-                        .address(address)
-                        .role(role)
-                        .refreshToken(refreshToken)
+                        .email(reqBody.email())
+                        .password(passwordEncoder.encode(reqBody.password()))
+                        .nickname(reqBody.nickname())
+                        .address(reqBody.address())
+                        .role(reqBody.role()) // USER, ADMIN을 입력하면 스프링이 자동으로 enum으로 매핑.
                         .build();
 
-        refreshToken.setMember(member);
+        // 액세스 & 리프레시 토큰 생성
+        String accessToken = generateAccessToken(member);
+        RefreshToken refreshToken = generateRefreshToken(member);
 
-        return memberRepository.save(member);
+        // 리프레시 토큰 저장
+        member.setRefreshToken(refreshToken);
+
+        // 응답 쿠키로 전달
+        setCookie("accessToken", accessToken);
+        setCookie("refreshToken", refreshToken.getToken());
+
+        return new MemberDto(memberRepository.save(member));
+    }
+
+    // 로그인 로직
+    @Transactional
+    public MemberLoginResponseDto login(MemberLoginRequestDto reqBody) {
+        // 이메일로 회원 조회
+        Member member = findByEmail(reqBody.email())
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        // 비밀번호 확인
+        checkPassword(member, reqBody.password());
+
+        // 로그인 성공 시, 액세스 토큰과 리프레시 토큰 생성
+        String accessToken = generateAccessToken(member);
+        refreshTokenRepository.findByMemberId(member.getId())
+                .ifPresentOrElse(
+                        existing -> {
+                            // 기존 리프레시 토큰이 있다면 업데이트
+                            existing.setRefreshToken(UUID.randomUUID().toString());
+                            refreshTokenRepository.save(existing);
+                        },
+                        () -> {
+                            // 기존 리프레시 토큰이 없다면 새로 생성
+                            refreshTokenRepository.save(generateRefreshToken(member));
+                        }
+                );
+
+        // 응답 쿠키로 전달
+        setCookie("accessToken", accessToken);
+        setCookie("refreshToken", member.getRefreshToken().getToken());
+
+        return new MemberLoginResponseDto(
+                new MemberDto(memberRepository.save(member)),
+                member.getRole(),
+                accessToken,
+                member.getRefreshToken().getToken()
+        );
+    }
+
+    private void setCookie(String name, String value) {
+        if (value == null) value = "";
+
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setDomain("localhost");
+        cookie.setSecure(true);
+        cookie.setAttribute("SameSite", "Strict");
+
+        if (value.isBlank()) cookie.setMaxAge(0);
+        else cookie.setMaxAge(60 * 60 * 24 * 365);
+
+        resp.addCookie(cookie);
+    }
+
+    public void deleteCookie(String name) {
+        setCookie(name, null);
     }
 
     public Optional<Member> findByEmail(String email) {
         return memberRepository.findByEmail(email);
-    }
-
-    public Optional<Member> findByRefreshToken(RefreshToken refreshToken) {
-        return memberRepository.findByRefreshToken(refreshToken);
     }
 
     public Optional<Member> findById(long id) {
@@ -69,8 +137,12 @@ public class MemberService {
         return authTokenService.generateAccessToken(member);
     }
 
-    public String generateRefreshToken() {
-        return authTokenService.generateRefreshToken();
+    public RefreshToken generateRefreshToken(Member member) {
+        return authTokenService.generateRefreshToken(member);
+    }
+
+    public Optional<Member> findByRefreshToken(RefreshToken refreshToken) {
+        return memberRepository.findByRefreshToken(refreshToken);
     }
 
     public void checkPassword(Member member, String password) {

--- a/backend/src/main/java/com/back/domain/product/controller/ProductController.java
+++ b/backend/src/main/java/com/back/domain/product/controller/ProductController.java
@@ -84,7 +84,7 @@ public class ProductController {
 
 //        post.checkActorCanModify(actor);
 
-        ProductDto productDto = productService.update(productService.findById(productId), reqBody);
+        ProductDto productDto = productService.update(productId, reqBody);
 
         // 성공 응답
         return ResponseEntity.ok(

--- a/backend/src/main/java/com/back/domain/product/service/ProductService.java
+++ b/backend/src/main/java/com/back/domain/product/service/ProductService.java
@@ -31,7 +31,9 @@ public class ProductService {
     }
 
     @Transactional
-    public ProductDto update(Product product, ProductUpdateRequestDto reqBody) {
+    public ProductDto update(Long productId, ProductUpdateRequestDto reqBody) {
+        Product product = findById(productId);
+
         product.update(
                 reqBody.name(),
                 reqBody.price(),
@@ -55,7 +57,6 @@ public class ProductService {
                 .toList();
     }
 
-    @Transactional(readOnly = true)
     public Product findById(Long id) {
         return productRepository.findById(id)
                 .orElseThrow(() -> new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));

--- a/backend/src/main/java/com/back/global/jwt/authtoken/service/AuthTokenService.java
+++ b/backend/src/main/java/com/back/global/jwt/authtoken/service/AuthTokenService.java
@@ -1,6 +1,8 @@
 package com.back.global.jwt.authtoken.service;
 
 import com.back.domain.member.entity.Member;
+import com.back.global.jwt.refreshtoken.entity.RefreshToken;
+import com.back.global.jwt.refreshtoken.repository.RefreshTokenRepository;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
@@ -21,6 +23,7 @@ import java.util.UUID;
 @Service
 @RequiredArgsConstructor
 public class AuthTokenService {
+    private final RefreshTokenRepository refreshTokenRepository;
     // JWT 서명에 사용되는 비밀 키
     @Value("${custom.jwt.secretKey}")
     private String jwtSecretKey;
@@ -89,7 +92,12 @@ public class AuthTokenService {
     }
 
     // Refresh Token 생성
-    public String generateRefreshToken() {
-        return UUID.randomUUID().toString(); // 랜덤 UUID를 리프레시 토큰으로
+    public RefreshToken generateRefreshToken(Member member) {
+        RefreshToken refreshToken = RefreshToken.builder()
+                .token(UUID.randomUUID().toString()) // 랜덤 UUID를 리프레시 토큰으로
+                .member(member)
+                .build();
+
+        return refreshTokenRepository.save(refreshToken);
     }
 }

--- a/backend/src/main/java/com/back/global/jwt/refreshtoken/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/back/global/jwt/refreshtoken/repository/RefreshTokenRepository.java
@@ -3,6 +3,9 @@ package com.back.global.jwt.refreshtoken.repository;
 import com.back.global.jwt.refreshtoken.entity.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
+    Optional<RefreshToken> findByMemberId(Long memberId);
 }
 


### PR DESCRIPTION
### 📌 과제 설명 
토큰 재발급 로직, 쿠키 구현
----------------

### 👩‍💻 요구 사항과 구현 내용 
// 예시
- [X] 로그인 시 response 반환 값에 멤버 role 넣기
- [X] 로그인 컨트롤러에서 refresh token 생성하고 유저에 add하기
- [] /api/auth/refresh 엔드포인트로 토큰 유효성 검사 - 새로운 access token 발급 - refresh token 갱신(새로 발급) - 쿠키 사용하시면 쿠키 처리
------------------

### ✅ 특이 사항 
 - 토큰 유효성 검사는 구현 예정입니다
------------------

### 📕 관련 이슈
closed #50