### PR TITLE
fix/be: swagger 프리플라이트 차단 해결

### DIFF
--- a/backend/src/main/java/com/back/global/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/back/global/config/SwaggerConfig.java
@@ -18,8 +18,8 @@ import org.springframework.context.annotation.Configuration;
                 description = "Take Five Project API 명세서입니다"
         ),
         servers = {
-//                @Server(url = "배포할 도메인", description = "운영 서버"),
-                @Server(url = "http://localhost:8080", description = "로컬 서버")
+               @Server(url = "http://43.202.22.198:8080", description = "운영 서버"),
+//                @Server(url = "http://localhost:8080", description = "로컬 서버")
         }
 )
 @Configuration

--- a/backend/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/back/global/security/SecurityConfig.java
@@ -68,7 +68,7 @@ public class SecurityConfig {
 
         // CORS 설정을 소스에 등록
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/api/**", configuration);
+        source.registerCorsConfiguration("/**", configuration);
 
         return source;
     }


### PR DESCRIPTION
### 📌 과제 설명 

swagger 프리플라이트 차단 해결
----------------

### 👩‍💻 요구 사항과 구현 내용 

- [X] swagger 배포 url로 서버 바꿈
- [X] registerCorsConfiguration "/api/**" 로 설정되어있어 Swagger UI에서 API 호출 시 CORS 프리플라이트가 차단될 수 있는 문제 해결
       (swagger 경로가 /api로 시작하지 않기 때문임)
------------------

### ✅ 특이 사항 

------------------

### 📕 관련 이슈
closed #