### PR TITLE
fix/be: 회원가입 시 주소 작성하지 않도록, 회원 정보 수정 시 빈값 허용하도록 수정

### DIFF
--- a/backend/src/main/java/com/back/domain/member/dto/request/MemberInfoUpdateRequestDto.java
+++ b/backend/src/main/java/com/back/domain/member/dto/request/MemberInfoUpdateRequestDto.java
@@ -16,7 +16,6 @@ public record MemberInfoUpdateRequestDto(
         @Schema(description = "닉네임", example = "nickname123")
         String nickname,
 
-        @NotBlank
         @Size(min = 2, max = 100)
         @Schema(description = "주소", example = "서울시 강남구 역삼동")
         String address

--- a/backend/src/main/java/com/back/domain/member/dto/request/MemberJoinRequestDto.java
+++ b/backend/src/main/java/com/back/domain/member/dto/request/MemberJoinRequestDto.java
@@ -24,11 +24,6 @@ public record MemberJoinRequestDto(
         @Schema(description = "닉네임", example = "nickname123")
         String nickname,
 
-        @NotBlank
-        @Size(min = 2, max = 100)
-        @Schema(description = "주소", example = "서울시 강남구 역삼동")
-        String address,
-
         @NotNull
         @Schema(description = "역할", example = "USER", allowableValues = {"USER", "ADMIN"})
         Role role

--- a/backend/src/main/java/com/back/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/back/domain/member/entity/Member.java
@@ -69,11 +69,10 @@ public class Member {
     private RefreshToken refreshToken;
 
     @Builder
-    public Member(String email, String password, String nickname, String address, Role role) {
+    public Member(String email, String password, String nickname, Role role) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
-        this.address = address;
         this.role = role;
     }
 

--- a/backend/src/main/java/com/back/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/back/domain/member/service/MemberService.java
@@ -51,7 +51,6 @@ public class MemberService {
                         .email(reqBody.email())
                         .password(passwordEncoder.encode(reqBody.password()))
                         .nickname(reqBody.nickname())
-                        .address(reqBody.address())
                         .role(reqBody.role()) // USER, ADMIN을 입력하면 스프링이 자동으로 enum으로 매핑.
                         .build();
 


### PR DESCRIPTION
### 📌 과제 설명 
회원가입 시 주소 작성하지 않도록, 회원 정보 수정 시 빈값 허용하도록 수정
----------------

### 👩‍💻 요구 사항과 구현 내용 
- [X] MemberJoinRequestDto 의 address 빼기
- [X] MemberInfoUpdateRequestDto의 address에서 @notblank 제거
------------------

### ✅ 특이 사항 
------------------

### 📕 관련 이슈
closed #92