### PR TITLE
fix: logout 매핑 변경

### DIFF
--- a/backend/src/main/java/com/back/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/back/domain/member/controller/MemberController.java
@@ -57,7 +57,7 @@ public class MemberController {
     }
 
     @Operation(summary = "로그아웃", description = "로그아웃 API")
-    @DeleteMapping("/logout")
+    @PostMapping("/logout")
     public ResponseEntity<ApiResponse<String>> logout() {
         memberService.logout();
 


### PR DESCRIPTION
### 📌 과제 설명 

 logout 매핑 변경
----------------

### 👩‍💻 요구 사항과 구현 내용 

- [X] Spring Security 기본 로그아웃 URL과 동기화 문제
	•	Spring Security를 사용하는 경우, 로그아웃은 기본적으로 POST 방식의 `/logout`입니다.
	•	프론트에서 DELETE 방식이나 다른 URL로 요청하거나, 백엔드 설정과 불일치 시 404가 발생할 수 있습니다
라네요
------------------

### ✅ 특이 사항 

------------------

### 📕 관련 이슈
closed #