### PR TITLE
Feature/fe: 주문 내역 수정

### DIFF
--- a/frontend/src/app/orders/page.tsx
+++ b/frontend/src/app/orders/page.tsx
@@ -1,59 +1,43 @@
 "use client";
 
 import { useOrders } from "@/hooks/useOrders";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useAuthContext } from "@/hooks/useAuth";
-import type { Order } from "@/types/dev/order";
+import type {CustomOrderResponseDto, Order} from "@/types/dev/order";
 import { RecipientData } from "@/components/orders/recipientData";
-import { OrderSummary } from "@/components/orders/orderSummary";
 import { TbShoppingCartExclamation } from "react-icons/tb";
 import Link from "next/link";
-import {formatDate} from "@/components/orders/format";
+import { formatPrice } from "@/components/orders/format";
+import { RedirectLayout } from "@/components/common/redirect";
+import { get } from "@/lib/fetcher";
+import {fromAdminDetailResponseDto, fromOrderResponseDto} from "@/components/orders/convertOrderDtos";
+import ConfirmModal from "@/components/modal/ConfirmModal";
+import {useRouter} from "next/navigation";
 
 const PAGE_SIZE = 6
 
 export default function OrderHistory() {
-    const [amounts, setAmounts] = useState<{[key: string]: number}>({});
-    const { orders, loading, error, cancelOrder, orderCanceled } = useOrders();
+    const {
+        orders,
+        cancelOrder,
+        orderCanceled,
+        detailRequestUrl,
+        getMemberIdFromLocalStorage
+    } = useOrders();
+
+    const router = useRouter();
     const [page, setPage] = useState(1);
     const [selectedOrder, setSelectedOrder] = useState<Order | null>(null);
+    const [clickedOrder, setClickedOrder] = useState<number | null>(null);
+    const [cancelPendingOrder, setCancelPendingOrder] = useState<number | null>(null);
     const { getUserRole } = useAuthContext();
+    const [orderDetail, setOrderDetail] = useState<CustomOrderResponseDto | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [showOrderCancelModal, setShowOrderCancelModal] = useState(false);
+    const [viewCancelFailedModal, setViewCancelFailedModal] = useState(false);
 
-    useEffect(() => {
-        // user가 없을 때 로그인 페이지로 리다이렉트
-        // if (user === null) {
-        //     router.replace("/auth/login");
-        //     return
-        // }
-
-        // 각 주문의 총 개수를 계산하여 저장
-        if (orders) {
-            const newAmounts: {[key: string]: number} = {};
-            orders.forEach(order => {
-                newAmounts[order.id] = order.orderItems?.reduce((sum, item) => sum + item.count, 0) || 0;
-            });
-            setAmounts(newAmounts);
-        }
-
-    }, [orders]);
-
-    // 로그인하지 않은 경우 로딩 표시
     if (getUserRole() === 'GUEST') {
-        return <div className="flex justify-center items-center min-h-screen">로딩중...</div>;
-    }
-
-    if ( orders === null || orders?.length === 0) {
-        return (
-            <div className="flex flex-col justify-center items-center min-h-screen gap-4">
-                <TbShoppingCartExclamation className="w-16 h-16 text-gray-600" />
-                <span className="text-lg text-gray-700">구매 내역이 없어요.</span>
-                <Link href="/">
-                    <button className="px-6 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors">
-                        구매하러 가기
-                    </button>
-                </Link>
-            </div>
-        );
+        return <RedirectLayout />
     }
 
     const total = orders ? orders.length : 0;
@@ -64,28 +48,123 @@ export default function OrderHistory() {
 
     const handleOrderClick = (order: Order) => {
         // 같은 주문을 클릭하면 닫기, 다른 주문을 클릭하면 해당 주문 표시
-        setSelectedOrder(selectedOrder?.id === order.id ? null : order);
+        setLoading(true);
+
+        const orderDetailPath = () => {
+            const role = getUserRole();
+
+            if (role === "ADMIN") {
+                return detailRequestUrl(order.id);
+            } else if (role === "USER") {
+                return `/api/orders/${order.id}`;
+            }
+
+            return "";
+        }
+
+        const isSameOrder = selectedOrder?.id === order.id;
+        const isDuplicatedClick = isSameOrder && clickedOrder === order.id;
+        setSelectedOrder(isSameOrder ? null : order);
+
+        // 1번 주문을 봤고 해당 주문을 보지 않기 위해 클릭하면
+        // 또 request가 요청되는 현상 수정
+        if (isDuplicatedClick) {
+            setClickedOrder(null);
+            return;
+        }
+        setClickedOrder(order.id);
+
+        const orderDetail = orderDetailPath();
+        get(orderDetail).then(response => {
+            if (response.error) {
+                return;
+            }
+
+            const data = response.data.content
+            let result = null;
+
+            if (getUserRole() === "ADMIN") {
+                result = fromAdminDetailResponseDto(data);
+            } else if (getUserRole() === "USER") {
+                const memberId = getMemberIdFromLocalStorage();
+                result = fromOrderResponseDto(data, order, memberId);
+            }
+
+            if (!result) {
+                return;
+            }
+
+            setOrderDetail(result);
+            setLoading(false);
+        })
     };
 
     // 주문 취소 핸들러
     const handleCancelOrder = (orderId: number, e: React.MouseEvent) => {
         e.stopPropagation(); // 주문 상세 토글 방지
-        if (!confirm('정말로 이 주문을 취소하시겠습니까?')) {
+        setShowOrderCancelModal(true);
+    };
+
+    const executeCancelOrder = (orderId: number | null) => {
+        if (!orderId) {
             return;
         }
 
         cancelOrder(orderId);
         if (orderCanceled) {
             setSelectedOrder(null);
-        } // 상세 정보 닫기
-    };
+        }
+        if (loading) {
+            setViewCancelFailedModal(true);
+        }
+        setShowOrderCancelModal(false);
+    }
+
+    const refreshCurrentWindows = () => {
+        setViewCancelFailedModal(false);
+        router.refresh();
+    }
+
+    const cancelExecuteCancelOrder = () => {
+        setCancelPendingOrder(null);
+        setShowOrderCancelModal(false);
+    }
+
+
+    if ( orders?.length === 0) {
+        return (
+            <div className="flex flex-col justify-center items-center min-h-screen gap-4">
+                <TbShoppingCartExclamation className="w-16 h-16 text-gray-600" />
+                <span className="text-lg text-gray-700">구매 내역이 없어요.</span>
+                {getUserRole() === "USER" && (
+                    <Link href="/">
+                        <button className="px-6 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors cursor-pointer">
+                            구매하러 가기
+                        </button>
+                    </Link>
+                )}
+            </div>
+        );
+    }
 
     return (
         <main className="max-w-[1280px] mx-auto bg-white">
+            {showOrderCancelModal && (
+                <ConfirmModal
+                    message={"주문을 취소하시겠습니까?\n이후에 더는 취소하실 수 없습니다."}
+                    onConfirm={() => {executeCancelOrder(cancelPendingOrder)}}
+                    onCancel={cancelExecuteCancelOrder}
+                />
+            )}
+            {viewCancelFailedModal && (
+                <ConfirmModal
+                    message={"주문을 취소하는데 실패했습니다.\n갱신을 위해 새로고침 합니다"}
+                    onConfirm={refreshCurrentWindows}
+                    onCancel={refreshCurrentWindows}
+                />
+            )}
             <div className="p-8">
                 <h1 className="text-2xl font-bold mb-8">주문 내역</h1>
-                {loading && <div className="flex justify-center items-center min-h-screen">로딩중...</div>}
-                {error && <div className="text-red-500">{error}</div>}
                 <div className="grid gap-6 mb-8">
                     {pageOrders.map((order, index) => (
                         <div key={order.id}>
@@ -95,43 +174,28 @@ export default function OrderHistory() {
                             >
                                 <div className="flex items-center">
                                     <span className="mr-4 text-lg font-semibold">{startIdx + index + 1}</span>
-                                    {getUserRole() === "ADMIN"
-                                        ? <span className="px-2">{order.memberName} 님</span> : <></>
-                                    }
+                                    {getUserRole() === "ADMIN" ? <span className="px-2">{order?.memberName} 님</span> : <></>}
                                     <span className="px-2">
-                                        {order.orderItems && order.orderItems[0]
-                                            ? `${order.orderItems[0].productName} 등 ${order.totalCount}종`
-                                            : '정보 없음'
-                                        }
-                                    </span>
+                                            {order.orderItemSize >= 2
+                                                ? `${order.orderItemFirstName} 등 ${order.orderItemSize}종`
+                                                : order.orderItemSize == 1
+                                                    ? `${order.orderItemFirstName} ${order.totalCount}개`
+                                                    : "정보 없음"
+                                            }
+                                        </span>
                                 </div>
                                 <div>
                                     <span className="mr-4">총 결제 금액</span>
-                                    <span className="text-lg font-semibold">{new Intl.NumberFormat("ko-KR").format(order.totalPrice)} 원</span>
+                                    <span className="text-lg font-semibold">{formatPrice(order.totalPrice)} 원</span>
                                 </div>
                             </div>
-
-                            {/* 주문 상세 정보 표시 영역 */}
-                            {selectedOrder?.id === order.id && (
-                                <div className="border-l border-r border-b border-gray-500 px-7 bg-blue-50">
-                                    <div className="flex justify-end">
-                                        <button
-                                            className="text-xs text-gray-500 hover:text-gray-700 underline py-4 cursor-pointer"
-                                            onClick={(e) => handleCancelOrder(order.id, e)}
-                                        >
-                                            주문 취소
-                                        </button>
-                                    </div>
-                                    <div className="flex justify-between items-start">
-                                        <RecipientData order={order} />
-                                        <div className="flex-1 ml-8">
-                                            <div className="text-right mb-4 flex justify-end items-center gap-4">
-                                                <p className="text-sm text-gray-600">주문일: {formatDate(order.createdAt)}</p>
-                                            </div>
-                                            <OrderSummary order={order} amounts={amounts} />
-                                            </div>
-                                    </div>
-                                </div>
+                            {selectedOrder?.id === order.id && !loading &&(
+                                <RecipientData
+                                    order={order}
+                                    handleCancelOrder={handleCancelOrder}
+                                    orderDetail={orderDetail}
+                                    setCancelPendingOrder={setCancelPendingOrder}
+                                />
                             )}
                         </div>
                     ))}

--- a/frontend/src/components/orders/convertOrderDtos.tsx
+++ b/frontend/src/components/orders/convertOrderDtos.tsx
@@ -1,0 +1,86 @@
+import {
+    type AdminDetailResponseDto,
+    type OrderResponseDto,
+         AdminViewerResponseDto,
+         CustomOrderResponseDto,
+         Order,
+         OrderSimpleResponseDto
+} from "@/types/dev/order";
+
+export const fromMemberSimpleOrders = (dtoList: OrderSimpleResponseDto[] | null) : Order[] => {
+    if (!dtoList || !Array.isArray(dtoList)) {
+        return [];
+    }
+
+    return dtoList.map(dto => {
+        if (!dto) {
+            return null;
+        }
+
+        return {
+            id: dto.orderId || 0,
+            totalPrice: dto.totalPrice || 0,
+            totalCount: dto.totalCount || 0,
+            orderItemFirstName: dto.orderItemFirstName || '',
+            orderItemSize: dto.orderItemSize || 0
+        }
+    }).filter(order => order !== null) as Order[];
+}
+
+export const fromAdminSimpleOrders = (dtoList: AdminViewerResponseDto[] | null) : Order[] => {
+    if (!dtoList || !Array.isArray(dtoList)) {
+        return [];
+    }
+
+    return dtoList.map(dto => {
+        const simpleDto = dto.orderSimpleResponseDto;
+
+        if (!simpleDto) {
+            return null;
+        }
+
+        return {
+            id: simpleDto.orderId || 0,
+            totalPrice: simpleDto.totalPrice || 0,
+            totalCount: simpleDto.totalCount || 0,
+            orderItemFirstName: simpleDto.orderItemFirstName || '',
+            orderItemSize: simpleDto.orderItemSize || 0,
+            memberId: dto.memberId,
+            memberName: dto.memberName,
+            deliveryStatus: dto.deliveryStatus,
+            trackingNumber: dto.trackingNumber
+        };
+    }).filter(order => order !== null) as Order[];
+}
+
+export const fromAdminDetailResponseDto = (data: AdminDetailResponseDto) : CustomOrderResponseDto => {
+    const dto = data.orderResponseDto;
+
+    return {
+        memberId: data.memberId,
+        orderId: dto.orderId,
+        memberName: dto.memberName,
+        address: dto.address,
+        totalPrice: dto.totalPrice,
+        totalCount: dto.totalCount,
+        createdAt: dto.createdAt,
+        deliveryStatus: dto.deliveryStatus,
+        trackingNumber: data.trackingNumber,
+        orderItems: dto.orderItems
+    }
+}
+
+export const fromOrderResponseDto = (data: OrderResponseDto, order: Order, memberId: number) : CustomOrderResponseDto => {
+    return {
+        memberId: memberId,
+        orderId: order.id,
+        memberName: data.memberName,
+        address: data.address,
+        totalPrice: data.totalPrice,
+        totalCount: data.totalCount,
+        createdAt: data.createdAt,
+        deliveryStatus: data.deliveryStatus,
+        trackingNumber: order.trackingNumber,
+        orderItems: data.orderItems
+    }
+}

--- a/frontend/src/components/orders/deliveryStatus.ts
+++ b/frontend/src/components/orders/deliveryStatus.ts
@@ -1,0 +1,35 @@
+export type DeliveryStatus = 'READY' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED';
+
+export const getDeliveryStatusText = (status: DeliveryStatus): string => {
+    if (!status) return '알 수 없음';
+    
+    switch (status.toUpperCase()) {
+        case 'READY':
+            return '배송 준비 중';
+        case 'IN_PROGRESS':
+            return '배송 중';
+        case 'COMPLETED':
+            return '배송 완료';
+        case 'CANCELLED':
+            return '배송 취소';
+        default:
+            return '알 수 없음';
+    }
+};
+
+export const getDeliveryStatusColor = (status: DeliveryStatus): string => {
+    if (!status) return 'text-gray-500';
+    
+    switch (status.toUpperCase()) {
+        case 'READY':
+            return 'text-blue-600';
+        case 'IN_PROGRESS':
+            return 'text-orange-600';
+        case 'COMPLETED':
+            return 'text-green-600';
+        case 'CANCELLED':
+            return 'text-red-600';
+        default:
+            return 'text-gray-500';
+    }
+};

--- a/frontend/src/components/orders/orderListItem.tsx
+++ b/frontend/src/components/orders/orderListItem.tsx
@@ -1,12 +1,14 @@
-"use client";
-
-import {OrderItem} from "@/types/dev/order";
-import {formatPrice} from "@/components/orders/format";
+import { OrderItemResponseDto } from "@/types/dev/order";
+import { formatPrice } from "@/components/orders/format";
 import Link from "next/link";
 import { useState } from "react";
 import Image from "next/image";
 
-export function OrderListItem( { item } :  { item : OrderItem} ) {
+interface OrderListItemProps {
+    item : OrderItemResponseDto;
+}
+
+export function OrderListItem( { item } : OrderListItemProps ) {
     const [isHovered, setIsHovered] = useState(false);
     const [imageLoaded, setImageLoaded] = useState(false);
     const [imageError, setImageError] = useState(false);
@@ -16,6 +18,7 @@ export function OrderListItem( { item } :  { item : OrderItem} ) {
             <Link 
                 className="font-bold underline relative" 
                 href={`/products/${item.productId}`}
+                target="_blank"
                 onMouseEnter={() => setIsHovered(true)}
                 onMouseLeave={() => setIsHovered(false)}
             >
@@ -28,7 +31,7 @@ export function OrderListItem( { item } :  { item : OrderItem} ) {
                             {!imageError ? (
                                 <Image
                                     src={item.imagePath}
-                                    alt={item.productName}
+                                    alt={item?.productName ? item.productName : ""}
                                     fill
                                     className="object-cover rounded"
                                     onLoad={() => setImageLoaded(true)}
@@ -45,7 +48,7 @@ export function OrderListItem( { item } :  { item : OrderItem} ) {
             </Link>
             <div>
                 <span className="px-25">x {item.count}</span>
-                <span>{formatPrice(item.totalPrice)} 원</span>
+                <span>{item?.totalPrice ? formatPrice(item.totalPrice) : 0} 원</span>
             </div>
         </div>
     );

--- a/frontend/src/components/orders/orderSummary.tsx
+++ b/frontend/src/components/orders/orderSummary.tsx
@@ -1,23 +1,24 @@
 "use client";
 
 import {OrderListItem} from "@/components/orders/orderListItem";
-import {formatPrice} from "@/components/orders/format";
-import {Order} from "@/types/dev/order";
+import { formatPrice } from "@/components/orders/format";
+import {CustomOrderResponseDto, Order} from "@/types/dev/order";
 
-export function OrderSummary(
-    {order, amounts }:
-    {
-        order : Order;
-        amounts: {[key: string]: number}
-    }
-) {
+interface OrderProps {
+    orderDetail?: CustomOrderResponseDto | null
+    order: Order
+}
+
+export function OrderSummary({ orderDetail, order }: OrderProps) {
+    const orderItems = orderDetail?.orderItems;
+
     return (
         <div className="text-right">
             <h3 className="text-lg font-semibold mb-2">결제 금액</h3>
             <div className="space-y-1 text-sm">
-                {order.orderItems && order.orderItems.length > 0 ? (
-                    order.orderItems.map((item, idx) => (
-                        <OrderListItem key={idx} item={item} />
+                {orderItems && orderItems?.length > 0 ? (
+                    orderItems.map((item, idx) => (
+                        <OrderListItem key={idx} item={item}/>
                     ))
                 ) : (
                     <div className="flex justify-between">
@@ -25,11 +26,11 @@ export function OrderSummary(
                         <span>0 원</span>
                     </div>
                 )}
-                <hr className="my-2" />
+                <hr className="my-2"/>
                 <div className="flex justify-between font-semibold text-xl">
                     <div>
                         <span>총</span>
-                        <span className="px-3">{amounts[order.id] || 0} 개</span>
+                        <span className="px-3">{order.totalCount || 0} 개</span>
                     </div>
                     <span>{formatPrice(order.totalPrice)} 원</span>
                 </div>

--- a/frontend/src/components/orders/recipientData.tsx
+++ b/frontend/src/components/orders/recipientData.tsx
@@ -1,56 +1,102 @@
-"use client";
-
-import { Order } from "@/types/dev/order";
-import { useMemo } from "react";
+import type { CustomOrderResponseDto, Order } from "@/types/dev/order";
+import { useMemo, useState } from "react";
+import { formatDate } from "@/components/orders/format";
+import { getDeliveryStatusText, getDeliveryStatusColor } from "@/components/orders/deliveryStatus";
+import { OrderSummary } from "@/components/orders/orderSummary";
 
 interface OrderProps {
     order: Order;
+    orderDetail: CustomOrderResponseDto | null;
+    handleCancelOrder: (id: number, e: React.MouseEvent) => void;
+    setCancelPendingOrder: (id: number | null) => void;
 }
 
-export function RecipientData({ order }: OrderProps) {
-    // useMemo를 사용해서 주소 파싱 결과를 캐싱
+export function RecipientData({ order, orderDetail, handleCancelOrder, setCancelPendingOrder }: OrderProps) {
+    const status = orderDetail.deliveryStatus;
+    const deliveryStatus = getDeliveryStatusText(status);
+    const trackingNumber = orderDetail?.trackingNumber ?? "";
+    const possibleCancelOrder = deliveryStatus === "배송 준비 중";
+
     const { baseAddress, extraAddress } = useMemo(() => {
-        if (!order.address) {
+        const address = orderDetail?.address;
+
+        if (!address) {
             return { baseAddress: '', extraAddress: '' };
         }
-        
-        const parts = order.address.split(', ', 2);
+
+        const parts = address.split(', ', 2);
+
+        if (parts.length === 1) {
+            return { baseAddress: parts[0], extraAddress: '' };
+        }
+
         return {
             baseAddress: parts[0] || '',
             extraAddress: parts[1] || ''
         };
-    }, [order.address]);
+    }, [orderDetail?.address]);
 
     return (
-        <div className="flex-1">
-            <h3 className="text-lg font-semibold mb-4">배송지</h3>
-            <div className="space-y-2 mb-6">
-                <div>
-                    <label className="block text-sm font-medium mb-1">수령인</label>
-                    <input
-                        type="text"
-                        className="w-48 p-2 border border-gray-300 rounded"
-                        value={order.memberName || ''}
-                        readOnly
-                    />
+        <div className="border-l border-r border-b border-gray-500 px-7 bg-blue-50">
+            <div className="flex">
+                <div className="flex items-center">
+                    <span className={`text-xl font-bold py-4 ${getDeliveryStatusColor(status)}`}>
+                        {deliveryStatus}
+                    </span>
+                    <span className="px-3 text-xs">{trackingNumber}</span>
                 </div>
-                <div>
-                    <label className="block text-sm font-medium mb-1">도로명 주소</label>
-                    <input
-                        type="text"
-                        className="w-full p-2 border border-gray-300 rounded"
-                        value={baseAddress}
-                        readOnly
-                    />
+                <div className="flex-1 flex justify-end">
+                    { possibleCancelOrder && (
+                        <button
+                            className="text-xs text-gray-500 hover:text-gray-700 underline py-4 cursor-pointer"
+                            onClick={(e) => {
+                                handleCancelOrder(order.id, e);
+                                setCancelPendingOrder(order.id);
+                            }}
+                        >
+                            주문 취소
+                        </button>
+                    )}
                 </div>
-                <div>
-                    <label className="block text-sm font-medium mb-1">상세 주소</label>
-                    <input
-                        type="text"
-                        className="w-full p-2 border border-gray-300 rounded"
-                        value={extraAddress}
-                        readOnly
-                    />
+            </div>
+            <div className="flex justify-between items-start">
+                <div className="flex-1">
+                    <h3 className="text-lg font-semibold mb-4">배송지</h3>
+                    <div className="space-y-2 mb-6">
+                        <div>
+                            <label className="block text-sm font-medium mb-1">수령인</label>
+                            <input
+                                type="text"
+                                className="w-48 p-2 border border-gray-300 rounded"
+                                value={orderDetail ? (orderDetail.memberName || '') : ''}
+                                readOnly
+                            />
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium mb-1">도로명 주소</label>
+                            <input
+                                type="text"
+                                className="w-full p-2 border border-gray-300 rounded"
+                                value={baseAddress}
+                                readOnly
+                            />
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium mb-1">상세 주소</label>
+                            <input
+                                type="text"
+                                className="w-full p-2 border border-gray-300 rounded"
+                                value={extraAddress}
+                                readOnly
+                            />
+                        </div>
+                    </div>
+                </div>
+                <div className="flex-1 ml-8">
+                    <div className="text-right mb-4 flex justify-end items-center gap-4">
+                        <p className="text-sm text-gray-600">주문일: {orderDetail ? formatDate(orderDetail.createdAt) : "정보 없음"}</p>
+                    </div>
+                    <OrderSummary orderDetail={orderDetail} order={order} />
                 </div>
             </div>
         </div>

--- a/frontend/src/hooks/useOrders.ts
+++ b/frontend/src/hooks/useOrders.ts
@@ -1,65 +1,121 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState } from "react";
+import { useAuthContext } from "@/hooks/useAuth";
 import { get, del } from "@/lib/fetcher";
-import type { Order } from "@/types/dev/order";
+import { Order } from "@/types/dev/order";
+import { fromAdminSimpleOrders, fromMemberSimpleOrders } from "@/components/orders/convertOrderDtos";
+import { useRouter } from "next/navigation";
 
-interface UseOrdersReturn {
+interface BaseOrderReturn {
     orders: Order[] | null;
     loading: boolean;
     error: string | null;
     cancelOrder: (id: number) => void;
     orderCanceled: boolean;
+    detailRequestUrl: (orderId: number) => string;
+    getMemberIdFromLocalStorage: () => number;
 }
 
-export function useOrders(): UseOrdersReturn {
-    const [orders, setOrders] = useState<Order[] | null>(null);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
+function dummyFunction (data? : any) : Order[] {
+    return [];
+}
+
+export function useOrders(): BaseOrderReturn {
+    const router = useRouter();
     const [orderCanceled, setOrderCanceled] = useState(false);
+    const { getUserRole, loginMember } = useAuthContext();
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [orders, setOrders] = useState<Order[] | null>(null);
+    const [baseUrl, setBaseUrl] = useState<string | null>(null);
+    const detailRequestUrl = (orderId: number) => {
+        return `${baseUrl}/${orderId}`;
+    }
+    const getMemberIdFromLocalStorage = () => {
+        let memberId = 0;
+        const loginState = localStorage.getItem("user-login-state");
 
-    const cancelOrder = (id: number) => {
-        del(`api/orders/${id}`)
-            .then((response) => {
-                if (response.error) {
-                    alert("주문취소에 실패했습니다.")
-                    return
-                }
+        if (loginState) {
+            try {
+                const parsed = JSON.parse(loginState);
+                memberId = parsed?.memberDto.id ?? 0;
+            } catch {
 
-                setOrderCanceled(true);
-                alert("주문취소가 성공하였습니다")
+            }
+        }
 
-                if (orders == null) {
-                    return;
-                }
-
-                setOrders(orders.filter(order => order.id !== id));
-            })
+        return memberId;
     }
 
-    const requestedRef = useRef(false);
     useEffect(() => {
-        if (requestedRef.current) return;
-        requestedRef.current = true;
         async function fetchOrders() {
             setLoading(true);
-            const response = await get<Order[]>("test/orders/data/order.json");
+            const userRole = getUserRole();
+
+            let requestUrl = '';
+            let converter: ((data: any) => Order[]) | null = dummyFunction;
+
+            if (userRole === "GUEST") {
+                return;
+            }
+
+            const memberId = getMemberIdFromLocalStorage();
+
+            if (userRole === "USER") {
+                requestUrl = `/api/orders/member/${memberId}`
+                converter = fromMemberSimpleOrders
+
+            } else if (userRole === "ADMIN") {
+                requestUrl = `/api/admin/dashboard/${memberId}`
+                converter = fromAdminSimpleOrders
+            }
+
+            const response = await get(requestUrl);
             if (response.error) {
-                setError(response.error);
+                setError(response.error)
                 setOrders(null);
             } else {
-                const data = response.data
-                    ? response.data.toSorted((a, b) => {
-                        const aDate = a?.createdAt ?? '';
-                        const bDate = b?.createdAt ?? '';
-                        return bDate.localeCompare(aDate);
-                    })
-                    : []
-                setOrders(data);
+                let orders : Order[] = []
+
+                if (converter) {
+                    orders = converter(response.data.content);
+                    orders = orders.toSorted((a, b) => b.id - a.id);
+                }
+
+                setOrders(orders);
+                setBaseUrl(requestUrl);
                 setError(null);
             }
             setLoading(false);
         }
         fetchOrders();
-    }, []);
+    }, [getUserRole, loginMember?.memberDto.id]);
 
-    return { orders, loading, error, cancelOrder, orderCanceled };
+    const cancelOrder = (orderId: number) => {
+        setLoading(true);
+
+        del(`/api/orders/${orderId}`).then((res) => {
+            if (res.error) {
+                return;
+            }
+
+            setOrderCanceled(true);
+
+            if (!orders) {
+                return;
+            }
+            setLoading(false);
+            setOrders(orders.filter(order => order.id !== orderId));
+            router.refresh();
+        })
+    }
+
+    return {
+        loading,
+        error,
+        orders,
+        orderCanceled,
+        cancelOrder,
+        detailRequestUrl,
+        getMemberIdFromLocalStorage
+    };
 }

--- a/frontend/src/types/dev/order.ts
+++ b/frontend/src/types/dev/order.ts
@@ -1,17 +1,88 @@
+// 구매 상세보기에 필요함
+
+import {DeliveryStatus} from "@/components/orders/deliveryStatus";
+
+export interface OrderResponseDto {
+    orderId: number;
+    memberName: string;
+    address: string;
+    /** Format: int32 */
+    totalPrice: number;
+    /** Format: int32 */
+    totalCount: number;
+    /** Format: date-time */
+    createdAt: string;
+    deliveryStatus: DeliveryStatus;
+    orderItems?: OrderItemResponseDto[];
+}
+
+// 구매한 물품의 상세 정보를 담은 객체
+export interface OrderItemResponseDto {
+    /** Format: int64 */
+    productId?: number;
+    productName?: string;
+    /** Format: int32 */
+    count?: number;
+    /** Format: int32 */
+    totalPrice?: number;
+    imagePath?: string;
+}
+
+// 사용자 구매 내역 조회 시 헤드 부분에 쓰일 객체
+export interface OrderSimpleResponseDto {
+    /** Format: int64 */
+    orderId?: number;
+    /** Format: int32 */
+    totalPrice?: number;
+    /** Format: int32 */
+    totalCount?: number;
+    orderItemFirstName?: string;
+    /** Format: int32 */
+    orderItemSize?: number;
+}
+
+// 관리자가 멤버 구매 내역 조회 시 사용될 객체
+export interface AdminViewerResponseDto {
+    /** Format: int64 */
+    memberId? : number;
+    memberName? : string;
+    deliveryStatus? : DeliveryStatus;
+    trackingNumber? : string;
+    orderSimpleResponseDto : OrderSimpleResponseDto
+}
+
+// 관리자가 상세정보를 보고자 할 때 쓸 객체
+export interface AdminDetailResponseDto {
+    memberId: number;
+    deliveryStatus: DeliveryStatus;
+    trackingNumber: string;
+    orderResponseDto: OrderResponseDto
+}
+
+// 헤드로 쓰일 AdminViewerResponseDto, OrderSimpleResponseDto을
+// 통합하고 사용하기 위해 별도로 정의한 DTO
 export interface Order {
     id: number;
+    totalPrice: number;
+    totalCount: number;
+    orderItemFirstName: string;
+    orderItemSize: number;
+    memberId?: number;
+    memberName?: string;
+    deliveryStatus?: DeliveryStatus;
+    trackingNumber?: string;
+}
+
+export interface CustomOrderResponseDto {
+    memberId: number;
+    orderId: number;
     memberName: string;
     address: string;
     totalPrice: number;
     totalCount: number;
-    createdAt: string;
-    orderItems: OrderItem[];
+    createdAt: string
+    deliveryStatus: DeliveryStatus;
+    trackingNumber?: string;
+    orderItems?: OrderSimpleResponseDto[]
 }
 
-export interface OrderItem {
-    productId: number;
-    productName: string;
-    count: number;
-    totalPrice: number;
-    imagePath: string;
-}


### PR DESCRIPTION
### 📌 과제 설명 
주문 내역 페이지와 관련된 작업 실시했습니다
----------------

### 👩‍💻 요구 사항과 구현 내용 
- [x] API 테스트 완료(주문 기본 * 상세 조회, 주문 취소)
- [x] 페이지에 배송 상태, 관리자는 회원의 운송장 번호 나오도록
- [x] 운송 상태가 '배송 준비 중' 일 때만 주문 취소 창이 나오도록 함
- [x] 주문 취소 창이 있는 상황에서 취소 불가한 상황으로 변경됐을 때, 주문 취소 시도 시 오류 처리
- [x] 팝업을 모달로 나오도록 변경
- [x] 구매 상세 내역 조회 후, 조회한 창을 한 번 더 클릭하면 요청이 한 번 더 들어가던 현상 수정   
------------------

### ✅ 특이 사항 
 - 헤더 부분에 주문 목록으로 가는 창이 없는 것 같아서 따로 추가하겠습니다.
------------------

### 📕 관련 이슈
closed #38 
closed #110 